### PR TITLE
Adds a like filter for string pattern matching

### DIFF
--- a/src/main/java/com/lifeinide/jsonql/jpa/JpaFilterQueryBuilder.java
+++ b/src/main/java/com/lifeinide/jsonql/jpa/JpaFilterQueryBuilder.java
@@ -128,6 +128,18 @@ extends BaseFilterQueryBuilder<E, P, CriteriaQuery<E>, JpaQueryBuilderContext<E>
 
 	@Nonnull
 	@Override
+	public JpaFilterQueryBuilder<E,P> add(@Nonnull String field, LikeQueryFilter filter) {
+		if (filter!=null) {
+			String pattern = filter.getPattern().toString();
+			Predicate predicate = pattern==null ? null : context.getCb().like(context.getRoot().get(field), pattern);
+			context.getPredicates().add(predicate);
+		}
+
+		return this;
+	}
+
+	@Nonnull
+	@Override
 	public JpaFilterQueryBuilder<E, P> add(@Nonnull String field, SingleValueQueryFilter<?> filter) {
 		if (filter!=null) {
 			context.getPredicates().add(JpaCriteriaBuilderHelper.INSTANCE.buildCriteria(filter.getCondition(),

--- a/src/main/java/com/lifeinide/jsonql/jpa/JpaFilterQueryBuilder.java
+++ b/src/main/java/com/lifeinide/jsonql/jpa/JpaFilterQueryBuilder.java
@@ -8,6 +8,7 @@ import com.lifeinide.jsonql.core.filters.*;
 import com.lifeinide.jsonql.core.intr.FilterQueryBuilder;
 import com.lifeinide.jsonql.core.intr.Pageable;
 import com.lifeinide.jsonql.core.intr.Sortable;
+import com.lifeinide.jsonql.jpa.filter.LikeQueryFilter;
 import org.hibernate.query.Query;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,12 +128,13 @@ extends BaseFilterQueryBuilder<E, P, CriteriaQuery<E>, JpaQueryBuilderContext<E>
 	}
 
 	@Nonnull
-	@Override
 	public JpaFilterQueryBuilder<E,P> add(@Nonnull String field, LikeQueryFilter filter) {
 		if (filter!=null) {
-			String pattern = filter.getPattern().toString();
+			String pattern = filter.getPattern();
 			Predicate predicate = pattern==null ? null : context.getCb().like(context.getRoot().get(field), pattern);
-			context.getPredicates().add(predicate);
+
+			if (predicate!=null)
+				context.getPredicates().add(predicate);
 		}
 
 		return this;

--- a/src/main/java/com/lifeinide/jsonql/jpa/JpaFilterQueryBuilder.java
+++ b/src/main/java/com/lifeinide/jsonql/jpa/JpaFilterQueryBuilder.java
@@ -129,12 +129,9 @@ extends BaseFilterQueryBuilder<E, P, CriteriaQuery<E>, JpaQueryBuilderContext<E>
 
 	@Nonnull
 	public JpaFilterQueryBuilder<E,P> add(@Nonnull String field, LikeQueryFilter filter) {
-		if (filter!=null) {
+		if (filter!=null && filter.getPattern()!=null) {
 			String pattern = filter.getPattern();
-			Predicate predicate = pattern==null ? null : context.getCb().like(context.getRoot().get(field), pattern);
-
-			if (predicate!=null)
-				context.getPredicates().add(predicate);
+			Predicate predicate = context.getCb().like(context.getRoot().get(field), pattern);
 		}
 
 		return this;

--- a/src/main/java/com/lifeinide/jsonql/jpa/filter/LikeQueryFilter.java
+++ b/src/main/java/com/lifeinide/jsonql/jpa/filter/LikeQueryFilter.java
@@ -1,0 +1,40 @@
+package com.lifeinide.jsonql.jpa.filter;
+
+import com.lifeinide.jsonql.core.intr.FilterQueryBuilder;
+import com.lifeinide.jsonql.core.intr.QueryFilter;
+
+/**
+ * Filter for for like pattern matching.
+ *
+ * @author Eric Wright
+ */
+public class LikeQueryFilter implements QueryFilter {
+
+	protected String pattern;
+
+	public LikeQueryFilter() {
+	}
+
+	public LikeQueryFilter with(String value) {
+		setPattern(value);
+		return this;
+	}
+
+	public String getPattern() {
+		return pattern;
+	}
+
+	public void setPattern(String pattern) {
+		this.pattern = pattern;
+	}
+
+	@Override
+	public void accept(FilterQueryBuilder builder, String field) {
+		builder.add(field, this);
+	}
+
+	public static LikeQueryFilter of(String pattern) {
+		return new LikeQueryFilter().with(pattern);
+	}
+
+}


### PR DESCRIPTION
I've bumped into a situation where it would be nice to allow for simple text searching with LIKE queries.  I've quickly prototyped this, and I would like your feedback.

I thought about adding this to the SingleValueFilter, with and adding a new QueryCondition for LIKE, but I'm not sure that's best.  LIKE operations really only make sense for String values and not other types.

I'll submit a similar pull request on jsonql-core with updates to the interface.

If you do choose to merge this in, you'll need to bump version numbers, I figured that wasn't my place.