### PR TITLE
Fixes Like filter tests

### DIFF
--- a/src/test/java/com/lifeinide/jsonql/jpa/test/JpaQueryBuilderTest.java
+++ b/src/test/java/com/lifeinide/jsonql/jpa/test/JpaQueryBuilderTest.java
@@ -2,6 +2,7 @@ package com.lifeinide.jsonql.jpa.test;
 
 import com.lifeinide.jsonql.core.dto.BasePageableRequest;
 import com.lifeinide.jsonql.core.dto.Page;
+import com.lifeinide.jsonql.core.dto.Sort;
 import com.lifeinide.jsonql.core.intr.PageableResult;
 import com.lifeinide.jsonql.core.test.JsonQLBaseQueryBuilderTest;
 import com.lifeinide.jsonql.jpa.JpaFilterQueryBuilder;
@@ -71,7 +72,7 @@ public class JpaQueryBuilderTest extends JsonQLBaseQueryBuilderTest<
 		doTest((pc, qb) -> {
 			PageableResult<JpaEntity> res = qb
 					.add("stringVal", LikeQueryFilter.of(SEARCHED_STRING_MATCHES))
-					.list(BasePageableRequest.ofUnpaged());
+					.list(BasePageableRequest.ofUnpaged().withSort(Sort.ofAsc("stringVal")));
 			Assertions.assertEquals(4, res.getCount()); // phrase-af, phrase-bf, phrase-cf, phrase-df
 			Assertions.assertEquals(SEARCHED_STRING_FIRST_MATCH, res.getData().iterator().next().getStringVal());
 		});

--- a/src/test/java/com/lifeinide/jsonql/jpa/test/JpaQueryBuilderTest.java
+++ b/src/test/java/com/lifeinide/jsonql/jpa/test/JpaQueryBuilderTest.java
@@ -32,9 +32,9 @@ public class JpaQueryBuilderTest extends JsonQLBaseQueryBuilderTest<
 
 	public static final String PERSISTENCE_UNIT_NAME = "test-jpa";
 
-	public static final String SEARCHED_STRING_MATCHES = "phrase-%";
+	public static final String SEARCHED_STRING_MATCHES = "phrase-%f";
 	public static final String SEARCHED_STRING_NOT_MATCHES = "phrase-not-exists-%";
-	public static final String SEARCHED_STRING_FIRST_MATCH = "phrase-1";
+	public static final String SEARCHED_STRING_FIRST_MATCH = "phrase-af";
 
 	protected EntityManagerFactory entityManagerFactory;
 
@@ -72,7 +72,7 @@ public class JpaQueryBuilderTest extends JsonQLBaseQueryBuilderTest<
 			PageableResult<JpaEntity> res = qb
 					.add("stringVal", LikeQueryFilter.of(SEARCHED_STRING_MATCHES))
 					.list(BasePageableRequest.ofUnpaged());
-			Assertions.assertEquals(100, res.getCount());
+			Assertions.assertEquals(4, res.getCount()); // phrase-af, phrase-bf, phrase-cf, phrase-df
 			Assertions.assertEquals(SEARCHED_STRING_FIRST_MATCH, res.getData().iterator().next().getStringVal());
 		});
 	}


### PR DESCRIPTION
Corrects test in the following ways:
Properly looks for strings in phrase-aa format, not phrase-00 (my misunderstanding)
No longer picks the same first value as would happen if filter not applied
Adds sort order to query as data source is not required to return results in order, although it always seems to

Remember version number in gradle config needs bumped before publishing